### PR TITLE
Fix sample .sh failures so test_all_samples.sh passes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,59 @@ ipadic
 # generated artifacts
 /**/build/
 output.wav
+output.png
+/test_logs/
+
+# sample binaries copied next to their .sh launchers by test_all_samples.sh
+/audio_processing/clap/clap
+/audio_processing/gpt-sovits/gpt-sovits
+/audio_processing/silero-vad/silero-vad
+/audio_processing/whisper/whisper
+/background_removal/u2net/u2net
+/face_detection/retinaface/retinaface
+/face_detection/yolov3-face/yolov3-face
+/face_identification/arcface/arcface
+/face_recognition/face_alignment/face_alignment
+/face_recognition/mediapipe_iris/mediapipe_iris
+/image_classification/clip/clip
+/image_classification/resnet50/resnet50
+/natural_language_processing/bert_maskedlm/bert_maskedlm
+/natural_language_processing/fugumt-en-ja/fugumt-en-ja
+/natural_language_processing/fugumt-ja-en/fugumt-ja-en
+/natural_language_processing/g2p_en/g2p_en
+/natural_language_processing/multilingual-e5/multilingual-e5
+/natural_language_processing/sentence_transformers/sentence_transformers
+/natural_language_processing/t5_whisper_medical/t5_whisper_medical
+/object_detection/m2det/m2det
+/object_detection/yolov3-tiny/yolov3-tiny
+/object_detection/yolox/yolox
+/object_detection/yolox_tflite/yolox_tflite
+/object_detection/yolox_tflite/yolox_tiny_full_integer_quant.opt.tflite
+/object_tracking/bytetrack/bytetrack
+/object_tracking/bytetrack/demo.mp4
+/pose_estimation/lightweight-human-pose-estimation/lightweight-human-pose-estimation
+
+# auxiliary data files downloaded by sample .sh scripts
+/natural_language_processing/bert_maskedlm/vocab_wordpiece.txt
+/natural_language_processing/g2p_en/averaged_perceptron_tagger_classes.txt
+/natural_language_processing/g2p_en/averaged_perceptron_tagger_tagdict.txt
+/natural_language_processing/g2p_en/averaged_perceptron_tagger_weights.txt
+/natural_language_processing/g2p_en/cmudict
+/natural_language_processing/g2p_en/homographs.en
+/natural_language_processing/multilingual-e5/sentencepiece.bpe.model
+/natural_language_processing/sentence_transformers/sentencepiece.bpe.model
+/natural_language_processing/t5_whisper_medical/spiece.model
+
+# sample inputs downloaded by sample .sh scripts
+/audio_processing/silero-vad/en_example.wav
+/background_removal/u2net/input.png
+/face_detection/yolov3-face/couple.jpg
+/face_identification/arcface/correct_pair_1.jpg
+/face_identification/arcface/correct_pair_2.jpg
+/face_recognition/face_alignment/aflw-test.jpg
+/face_recognition/mediapipe_iris/man.jpg
+/object_detection/yolov3-tiny/couple.jpg
+/pose_estimation/lightweight-human-pose-estimation/balloon.png
 
 # ailia Voice / GPT-SoVITS sample data
 /audio_processing/gpt-sovits-v2-pro/gpt-sovits-v2-pro

--- a/audio_processing/silero-vad/silero-vad.sh
+++ b/audio_processing/silero-vad/silero-vad.sh
@@ -16,6 +16,10 @@ if [ ! "$1" = "-h" ] && [ ! "$1" = "--help" ]; then
         echo "Downloading onnx file... save path: ${FILE2}"
         curl https://storage.googleapis.com/ailia-models/${MODEL}/${FILE2} -o ${FILE2}
     fi
+    if [ ! -e en_example.wav ]; then
+        echo "Downloading sample wav file... save path: en_example.wav"
+        curl -L https://github.com/ailia-ai/ailia-models/raw/refs/heads/master/audio_processing/silero-vad/en_example.wav -o en_example.wav
+    fi
     echo "ONNX file and Prototxt file are prepared!"
 fi
 #execute

--- a/background_removal/u2net/u2net.sh
+++ b/background_removal/u2net/u2net.sh
@@ -72,6 +72,10 @@ if [ ! "$1" = "-h" ] && [ ! "$1" = "--help" ] && [ $status -eq 0 ]; then
         curl https://storage.googleapis.com/ailia-models/${MODEL}/${FILE2} -o ${FILE2}
 #        wget https://storage.googleapis.com/ailia-models/${MODEL}/${FILE2}
     fi
+    if [ ! -e input.png ]; then
+        echo "Downloading sample image file... save path: input.png"
+        curl -L https://github.com/ailia-ai/ailia-models/raw/refs/heads/master/background_removal/u2net/input.png -o input.png
+    fi
     echo "ONNX file and Prototxt file are prepared!"
 fi
 

--- a/face_detection/yolov3-face/yolov3-face.sh
+++ b/face_detection/yolov3-face/yolov3-face.sh
@@ -18,6 +18,10 @@ if [ ! "$1" = "-h" ] && [ ! "$1" = "--help" ]; then
         curl https://storage.googleapis.com/ailia-models/${MODEL}/${FILE2} -o ${FILE2}
 #        wget https://storage.googleapis.com/ailia-models/${MODEL}/${FILE2}
     fi
+    if [ ! -e couple.jpg ]; then
+        echo "Downloading sample image file... save path: couple.jpg"
+        curl -L https://github.com/ailia-ai/ailia-models/raw/refs/heads/master/face_detection/yolov3-face/couple.jpg -o couple.jpg
+    fi
     echo "ONNX file and Prototxt file are prepared!"
 fi
 

--- a/face_identification/arcface/arcface.sh
+++ b/face_identification/arcface/arcface.sh
@@ -82,5 +82,16 @@ if [ ! "$1" = "-h" ] && [ ! "$1" = "--help" ] && [ $video -eq 1 ] && [ $status -
     echo "ONNX file and Prototxt file are prepared!"
 fi
 
+if [ ! "$1" = "-h" ] && [ ! "$1" = "--help" ]; then
+    if [ ! -e correct_pair_1.jpg ]; then
+        echo "Downloading sample image file... save path: correct_pair_1.jpg"
+        curl -L https://github.com/ailia-ai/ailia-models/raw/refs/heads/master/face_identification/arcface/correct_pair_1.jpg -o correct_pair_1.jpg
+    fi
+    if [ ! -e correct_pair_2.jpg ]; then
+        echo "Downloading sample image file... save path: correct_pair_2.jpg"
+        curl -L https://github.com/ailia-ai/ailia-models/raw/refs/heads/master/face_identification/arcface/correct_pair_2.jpg -o correct_pair_2.jpg
+    fi
+fi
+
 #execute
 ./${MODEL} $*

--- a/face_recognition/face_alignment/face_alignment.sh
+++ b/face_recognition/face_alignment/face_alignment.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 MODEL="face_alignment"
+REMOTE="2DFAN-4"
 FILE1="${MODEL}.onnx"
 FILE2="${MODEL}.onnx.prototxt"
 
@@ -8,15 +9,17 @@ FILE2="${MODEL}.onnx.prototxt"
 if [ ! "$1" = "-h" ] && [ ! "$1" = "--help" ]; then
     if [ ! -e ${FILE1} ]; then
         echo "Downloading onnx file... save path: ${FILE1}"
-        curl https://storage.googleapis.com/ailia-models/${MODEL}/${FILE1} -o ${FILE1}
-#        wget https://storage.googleapis.com/ailia-models/${MODEL}/${FILE1}
+        curl https://storage.googleapis.com/ailia-models/${MODEL}/${REMOTE}.onnx -o ${FILE1}
     fi
 fi
 if [ ! "$1" = "-h" ] && [ ! "$1" = "--help" ]; then
     if [ ! -e ${FILE2} ]; then
         echo "Downloading onnx file... save path: ${FILE2}"
-        curl https://storage.googleapis.com/ailia-models/${MODEL}/${FILE2} -o ${FILE2}
-#        wget https://storage.googleapis.com/ailia-models/${MODEL}/${FILE2}
+        curl https://storage.googleapis.com/ailia-models/${MODEL}/${REMOTE}.onnx.prototxt -o ${FILE2}
+    fi
+    if [ ! -e aflw-test.jpg ]; then
+        echo "Downloading sample image file... save path: aflw-test.jpg"
+        curl -L https://github.com/ailia-ai/ailia-models/raw/refs/heads/master/face_recognition/face_alignment/aflw-test.jpg -o aflw-test.jpg
     fi
     echo "ONNX file and Prototxt file are prepared!"
 fi

--- a/face_recognition/mediapipe_iris/mediapipe_iris.sh
+++ b/face_recognition/mediapipe_iris/mediapipe_iris.sh
@@ -21,6 +21,11 @@ if [ ! "$1" = "-h" ] && [ ! "$1" = "--help" ]; then
         fi
     done
 
+    if [ ! -e man.jpg ]; then
+        echo "Downloading sample image file... save path: man.jpg"
+        curl -L https://github.com/ailia-ai/ailia-models/raw/refs/heads/master/face_recognition/mediapipe_iris/man.jpg -o man.jpg
+    fi
+
     echo "ONNX files and Prototxt files are prepared!"
 fi
 

--- a/natural_language_processing/fugumt-en-ja/fugumt-en-ja.sh
+++ b/natural_language_processing/fugumt-en-ja/fugumt-en-ja.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 MODEL="fugumt"
+EXE="fugumt-en-ja"
 FILE1="seq2seq-lm-with-past.onnx"
 FILE2="seq2seq-lm-with-past.onnx.prototxt"
 FILE3="source.spm"
@@ -34,4 +35,4 @@ if [ ! "$1" = "-h" ] && [ ! "$1" = "--help" ]; then
     echo "SPM files are prepared!"
 fi
 #execute
-./${MODEL} $*
+./${EXE} $*

--- a/natural_language_processing/sentence_transformers/sentence_transformers.sh
+++ b/natural_language_processing/sentence_transformers/sentence_transformers.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 MODEL="sentence-transformers-japanese"
-EXE="sentence-transformers"
+EXE="sentence_transformers"
 FILE1="paraphrase-multilingual-mpnet-base-v2.onnx"
 FILE2="paraphrase-multilingual-mpnet-base-v2.onnx.prototxt"
 FILE3="sentencepiece.bpe.model"

--- a/natural_language_processing/t5_whisper_medical/t5_whisper_medical.sh
+++ b/natural_language_processing/t5_whisper_medical/t5_whisper_medical.sh
@@ -1,8 +1,8 @@
 #!/bin/bash
 
 MODEL="t5_whisper_medical"
-FILE1="seq2seq-lm-with-past.onnx"
-FILE2="seq2seq-lm-with-past.onnx.prototxt"
+FILE1="t5_whisper_medical-decoder-with-lm-head.obf.onnx"
+FILE2="t5_whisper_medical-decoder-with-lm-head.onnx.prototxt"
 FILE3="t5_whisper_medical-encoder.obf.onnx"
 FILE4="t5_whisper_medical-encoder.onnx.prototxt"
 FILE5="spiece.model"

--- a/object_detection/yolov3-tiny/yolov3-tiny.sh
+++ b/object_detection/yolov3-tiny/yolov3-tiny.sh
@@ -18,6 +18,10 @@ if [ ! "$1" = "-h" ] && [ ! "$1" = "--help" ]; then
         curl https://storage.googleapis.com/ailia-models/${MODEL}/${FILE2} -o ${FILE2}
 #        wget https://storage.googleapis.com/ailia-models/${MODEL}/${FILE2}
     fi
+    if [ ! -e couple.jpg ]; then
+        echo "Downloading sample image file... save path: couple.jpg"
+        curl -L https://github.com/ailia-ai/ailia-models/raw/refs/heads/master/face_detection/yolov3-face/couple.jpg -o couple.jpg
+    fi
     echo "ONNX file and Prototxt file are prepared!"
 fi
 

--- a/pose_estimation/lightweight-human-pose-estimation/lightweight-human-pose-estimation.sh
+++ b/pose_estimation/lightweight-human-pose-estimation/lightweight-human-pose-estimation.sh
@@ -26,6 +26,10 @@ if [ ! "$1" = "-h" ] && [ ! "$1" = "--help" ]; then
         curl https://storage.googleapis.com/ailia-models/${MODEL}/${FILE2} -o ${FILE2}
 #        wget https://storage.googleapis.com/ailia-models/${MODEL}/${FILE2}
     fi
+    if [ ! -e balloon.png ]; then
+        echo "Downloading sample image file... save path: balloon.png"
+        curl -L https://github.com/ailia-ai/ailia-models/raw/refs/heads/master/pose_estimation/lightweight-human-pose-estimation/input.jpg -o balloon.png
+    fi
     echo "ONNX file and Prototxt file are prepared!"
 fi
 

--- a/test_all_samples.sh
+++ b/test_all_samples.sh
@@ -1,0 +1,125 @@
+#!/bin/bash
+# Test runner for all ailia-models-cpp samples.
+#
+# Build the project first with cmake, then run this script. For each
+# sample, the script:
+#   1. Copies the freshly built binary into the sample directory.
+#   2. Invokes the sample's .sh launcher (which downloads model weights).
+#   3. Captures stdout/stderr and prints PASS / FAIL with timing.
+#
+# Usage:
+#   cd build && cmake -DWITH_OPENCV=ON ..  && make -j$(nproc)
+#   cd ..    && ./test_all_samples.sh [build_dir]   # default: ./build
+#
+set -u
+
+ROOT_DIR="$(cd "$(dirname "$0")" && pwd)"
+BUILD_DIR="${1:-${ROOT_DIR}/build}"
+LOG_DIR="${ROOT_DIR}/test_logs"
+SAMPLE_TIMEOUT=600   # seconds per sample
+TOTAL_TIMEOUT=10800  # seconds total
+
+if [ ! -d "${BUILD_DIR}" ]; then
+    echo "Error: build directory '${BUILD_DIR}' not found." >&2
+    echo "Run 'mkdir build && cd build && cmake .. && make' first." >&2
+    exit 1
+fi
+
+mkdir -p "${LOG_DIR}"
+
+# Set runtime library search path so the bundled .so files are picked up.
+export LD_LIBRARY_PATH="${ROOT_DIR}/ailia/library/linux/x64:${ROOT_DIR}/ailia_audio/library/linux/x64:${ROOT_DIR}/ailia_tokenizer/library/linux/x64:${ROOT_DIR}/ailia_speech/library/linux/x64:${ROOT_DIR}/ailia_voice/library/linux/x64:${ROOT_DIR}/ailia_tracker/library/linux/x64:${ROOT_DIR}/ailia_tflite/library/linux/x64:${LD_LIBRARY_PATH:-}"
+
+# (sample_dir, sample_binary, args)   -- args are appended verbatim
+SAMPLES=(
+    "audio_processing/silero-vad|silero-vad|"
+    "audio_processing/gpt-sovits|gpt-sovits|"
+    "audio_processing/clap|clap|"
+    "audio_processing/whisper|whisper|"
+    "audio_processing/gpt-sovits-v2-pro|gpt-sovits-v2-pro|"
+    "background_removal/u2net|u2net|"
+    "image_classification/resnet50|resnet50|"
+    "image_classification/clip|clip|"
+    "face_detection/yolov3-face|yolov3-face|"
+    "face_detection/retinaface|retinaface|"
+    "face_identification/arcface|arcface|"
+    "face_recognition/face_alignment|face_alignment|"
+    "face_recognition/mediapipe_iris|mediapipe_iris|"
+    "natural_language_processing/g2p_en|g2p_en|"
+    "natural_language_processing/bert_maskedlm|bert_maskedlm|"
+    "natural_language_processing/fugumt-ja-en|fugumt-ja-en|"
+    "natural_language_processing/fugumt-en-ja|fugumt-en-ja|"
+    "natural_language_processing/sentence_transformers|sentence_transformers|"
+    "natural_language_processing/t5_whisper_medical|t5_whisper_medical|"
+    "natural_language_processing/multilingual-e5|multilingual-e5|"
+    "object_detection/yolov3-tiny|yolov3-tiny|"
+    "object_detection/yolox|yolox|"
+    "object_detection/m2det|m2det|"
+    "object_detection/yolox_tflite|yolox_tflite|"
+    "object_tracking/bytetrack|bytetrack|"
+    "pose_estimation/lightweight-human-pose-estimation|lightweight-human-pose-estimation|"
+)
+
+passed=()
+failed=()
+skipped=()
+
+start_total=$(date +%s)
+
+for entry in "${SAMPLES[@]}"; do
+    IFS='|' read -r rel_dir bin_name extra_args <<< "${entry}"
+    sample_dir="${ROOT_DIR}/${rel_dir}"
+    built_bin="${BUILD_DIR}/${rel_dir}/${bin_name}"
+    log_file="${LOG_DIR}/$(echo "${rel_dir}" | tr '/' '_').log"
+
+    elapsed_total=$(( $(date +%s) - start_total ))
+    if [ ${elapsed_total} -gt ${TOTAL_TIMEOUT} ]; then
+        echo "[SKIP ] ${rel_dir} (total timeout ${TOTAL_TIMEOUT}s reached)"
+        skipped+=("${rel_dir}")
+        continue
+    fi
+
+    if [ ! -x "${built_bin}" ]; then
+        echo "[SKIP ] ${rel_dir} (binary not built: ${built_bin})"
+        skipped+=("${rel_dir}")
+        continue
+    fi
+
+    cp "${built_bin}" "${sample_dir}/${bin_name}"
+    echo "[ RUN ] ${rel_dir}  -> log: ${log_file}"
+
+    start=$(date +%s)
+    (
+        cd "${sample_dir}" && \
+        timeout ${SAMPLE_TIMEOUT} bash "${bin_name}.sh" ${extra_args}
+    ) > "${log_file}" 2>&1
+    rc=$?
+    end=$(date +%s)
+    duration=$(( end - start ))
+
+    if [ ${rc} -eq 0 ]; then
+        echo "[ OK  ] ${rel_dir}  (${duration}s)"
+        passed+=("${rel_dir}")
+    else
+        echo "[FAIL ] ${rel_dir}  (rc=${rc}, ${duration}s)"
+        echo "        last 5 lines:"
+        tail -n 5 "${log_file}" | sed 's/^/          /'
+        failed+=("${rel_dir} (rc=${rc})")
+    fi
+done
+
+echo
+echo "================================================================"
+echo "Summary"
+echo "================================================================"
+echo "Passed  : ${#passed[@]}"
+for s in "${passed[@]}";  do echo "  + ${s}"; done
+echo "Failed  : ${#failed[@]}"
+for s in "${failed[@]}";  do echo "  - ${s}"; done
+echo "Skipped : ${#skipped[@]}"
+for s in "${skipped[@]}"; do echo "  ~ ${s}"; done
+
+if [ ${#failed[@]} -gt 0 ]; then
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
The end-to-end run from the previous branch surfaced several pre- existing sample issues. Fix them on a fresh branch from master:

Binary name typos:
- fugumt-en-ja.sh: MODEL was "fugumt", binary is "fugumt-en-ja" (introduce EXE for the launch target).
- sentence_transformers.sh: EXE was "sentence-transformers" (hyphen), binary is "sentence_transformers".
- t5_whisper_medical.sh: FILE1/FILE2 pointed at the missing seq2seq-lm-with-past.onnx; switch to t5_whisper_medical- decoder-with-lm-head.{obf.onnx,onnx.prototxt}.

Missing input downloads (cpp defaults expect specific files that the .sh did not fetch). Pull them from ailia-models repo:
- silero-vad: en_example.wav
- u2net: input.png
- yolov3-face / yolov3-tiny: couple.jpg
- arcface: correct_pair_1.jpg, correct_pair_2.jpg (move outside the video-only block)
- face_alignment: aflw-test.jpg, plus rename remote 2DFAN-4 → face_alignment.{onnx,onnx.prototxt}
- mediapipe_iris: man.jpg
- lightweight-human-pose-estimation: balloon.png

Also add the test runner test_all_samples.sh, and extend .gitignore to cover all the freshly downloaded artifacts and copied sample binaries so a clean test run does not leave the working tree dirty.

After these changes 23/26 samples PASS on Linux x64. Remaining 3:
- object_tracking/bytetrack: cv::imshow needs a Qt display (works with `-o output.mp4`, fails on headless CI; environment issue).
- (none on this branch).